### PR TITLE
Make it possible to override the parsing behavior by making some classes public.

### DIFF
--- a/src/HttpMessageSigning.Verification.AspNetCore/SignatureParsingFailure.cs
+++ b/src/HttpMessageSigning.Verification.AspNetCore/SignatureParsingFailure.cs
@@ -1,7 +1,16 @@
 ﻿using System;
 
 namespace Dalion.HttpMessageSigning.Verification.AspNetCore {
-    internal class SignatureParsingFailure : SignatureParsingResult {
+    /// <summary>
+    /// Represents a parsing failure
+    /// </summary>
+    public class SignatureParsingFailure : SignatureParsingResult {
+        /// <summary>
+        /// Constructs a new parsing failure object 
+        /// </summary>
+        /// <param name="description">A description of the failure that occurred</param>
+        /// <param name="failure">An optional exception to attach to this failure object</param>
+        /// <exception cref="ArgumentException">Thrown if one of the parameters are invalid</exception>
         public SignatureParsingFailure(string description, Exception failure = null) {
             if (string.IsNullOrEmpty(description)) throw new ArgumentException("Value cannot be null or empty.", nameof(description));
             
@@ -9,9 +18,17 @@ namespace Dalion.HttpMessageSigning.Verification.AspNetCore {
             Failure = failure;
         }
         
+        /// <inheritdoc cref="IsSuccess"/>
         public override bool IsSuccess => false;
 
+        /// <summary>
+        /// A description of the failure
+        /// </summary>
         public string Description { get; }
+        
+        /// <summary>
+        /// An optional exception that was attached to this failure object
+        /// </summary>
         public Exception Failure { get; }
     }
 }

--- a/src/HttpMessageSigning.Verification.AspNetCore/SignatureParsingResult.cs
+++ b/src/HttpMessageSigning.Verification.AspNetCore/SignatureParsingResult.cs
@@ -1,5 +1,13 @@
 ﻿namespace Dalion.HttpMessageSigning.Verification.AspNetCore {
-    internal abstract class SignatureParsingResult {
+    /// <summary>
+    /// A base class to identify header parsing results.
+    /// <seealso cref="SignatureParsingSuccess"/>
+    /// <seealso cref="SignatureParsingFailure"/>
+    /// </summary>
+    public abstract class SignatureParsingResult {
+        /// <summary>
+        /// True if the parsing result was successful
+        /// </summary>
         public abstract bool IsSuccess { get; }
     }
 }

--- a/src/HttpMessageSigning.Verification.AspNetCore/SignatureParsingSuccess.cs
+++ b/src/HttpMessageSigning.Verification.AspNetCore/SignatureParsingSuccess.cs
@@ -1,13 +1,25 @@
 ﻿using System;
 
 namespace Dalion.HttpMessageSigning.Verification.AspNetCore {
-    internal class SignatureParsingSuccess : SignatureParsingResult {
+    /// <summary>
+    /// Represents a successful result in the parsing of a signature header
+    /// </summary>
+    public class SignatureParsingSuccess : SignatureParsingResult {
+        
+        /// <summary>
+        /// Constructs a new parsing success object 
+        /// </summary>
+        /// <param name="signature">The signature that was parsed</param>
         public SignatureParsingSuccess(Signature signature) {
             Signature = signature ?? throw new ArgumentNullException(nameof(signature));
         }
 
+        /// <inheritdoc cref="IsSuccess"/>
         public override bool IsSuccess => true;
 
+        /// <summary>
+        /// The parsed signature
+        /// </summary>
         public Signature Signature { get; }
     }
 }


### PR DESCRIPTION
This PR makes it possible to customize the behavior of the signature parsing by overriding the default signature parser and registering a different one at startup time.

Note that this PR makes some classes public and thus increases the exposed surface of the library.
These changes have the following advantages:
- A big part of the advantages of the ASP.net ecosystem is how customizable it is, and this makes it easier for people to customize one of the key behavior of this library.
- Enables people with needs that are not covered by the standard (e.g. different headers, different format...) to still take advantage of this library.
- It should help in the implementation the standard draft-ietf-httpbis-message-signatures-01: it should be possible to implement multiple parsers for the different revision of the standard (excluding the support for multiple signatures, which would break the contract for the parser.).

Disadvantages:
- It makes the classes public and with the 01 draft supporting multiple signatures it might result in a break of the public interface.

Context:
These changes were made because of a very urgent need in my company to be able to specify a different header name for signatures. We would now really love to upstream these changes to enable this use case for everybody else.

I'm open for any suggestion and feedback :)